### PR TITLE
Missing flight_record type

### DIFF
--- a/types/flight_record.sql
+++ b/types/flight_record.sql
@@ -1,0 +1,11 @@
+CREATE TYPE postgres_air.flight_record AS
+( 
+	flight_id int,
+	flight_no text,
+	departure_airport_code text,
+	departure_airport_name text,
+	arrival_airport_code text,
+	arrival_airport_name text,
+	scheduled_departure timestamp with time zone,
+	scheduled_arrival timestamp with time zone
+);


### PR DESCRIPTION
It seems that `flight_record` type is missing from the repo. Here is its definition per listing 11-20 of the book.